### PR TITLE
Use link to Jenkins plugins portal

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -82,8 +82,8 @@ You will be asked to set up an new administration user and which plugins to inst
 Confirm to install the recommended plugins when starting Jenkins for the first time.
 Under "Manage Jenkins > Manage Plugins" ensure that you have the following two plugins installed.
 
-* https://wiki.jenkins.io/display/JENKINS/Git+Plugin[Git plugin]
-* https://wiki.jenkins.io/display/JENKINS/Gradle+Plugin[Gradle plugin]
+* https://plugins.jenkins.io/git[Git plugin]
+* https://plugins.jenkins.io/gradle[Gradle plugin]
 
 Next, we can set up the job for building the project.
 


### PR DESCRIPTION
The wiki is stale and not updated anymore. Current plugins use
Github readme for the documentation. The documentation is then published
on plugins.jenkins.io, no matter if it comes from the wiki or Github.